### PR TITLE
Fixing getSystemLanguage function detection

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -618,7 +618,7 @@
 
     // Get System Language.  Return a string containing the system language.
     getSystemLanguage: function() {
-      return navigator.systemLanguage;
+      return navigator.systemLanguage || window.navigator.language;
     },
 
     //


### PR DESCRIPTION
Unfortunately `window.navigator.systemLanguage` works only for IE.
This quick fix add `window.navigator.language` support.
