### PR TITLE
Fix exception if navigator does not have mimeTypes attribute

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -523,7 +523,7 @@
 
     // Is Mime Types.  Check if a mime type is installed.
     isMimeTypes: function() {
-      if (navigator.mimeTypes.length) {
+      if (navigator.mimeTypes && navigator.mimeTypes.length) {
         return true;
       }
       return false;
@@ -533,11 +533,13 @@
     getMimeTypes: function() {
       var mimeTypeList = "";
 
-      for (var i = 0; i < navigator.mimeTypes.length; i++) {
-        if (i == navigator.mimeTypes.length - 1) {
-          mimeTypeList += navigator.mimeTypes[i].description;
-        } else {
-          mimeTypeList += navigator.mimeTypes[i].description + ", ";
+      if(navigator.mimeTypes) {
+        for (var i = 0; i < navigator.mimeTypes.length; i++) {
+          if (i == navigator.mimeTypes.length - 1) {
+            mimeTypeList += navigator.mimeTypes[i].description;
+          } else {
+            mimeTypeList += navigator.mimeTypes[i].description + ", ";
+          }
         }
       }
       return mimeTypeList;


### PR DESCRIPTION
Some IE browser mods don't have `navigator.mimeTypes` property.
As a result, we've got an error "Unable to get property 'length' of undefined or null reference" when using `getMimeTypes` or `isMimeTypes` functions.
This fix adds check on existing navigator.mimeTypes property before reading `navigator.mimeTypes.length`.
