### PR TITLE
Fix getTimeZone for across browsers support

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -604,7 +604,7 @@
     // Get Time Zone.  Return a string containing the time zone.
     getTimeZone: function() {
       var rightNow = new Date();
-      return String(String(rightNow).split("(")[1]).split(")")[0];
+      return String(-(rightNow.getTimezoneOffset()/60));
     },
 
     //

--- a/src/client.js
+++ b/src/client.js
@@ -603,8 +603,18 @@
 
     // Get Time Zone.  Return a string containing the time zone.
     getTimeZone: function() {
-      var rightNow = new Date();
-      return String(-(rightNow.getTimezoneOffset()/60));
+      var rightNow, myNumber, formattedNumber, result;
+        rightNow = new Date();
+        myNumber = String(-(rightNow.getTimezoneOffset() / 60));
+        if (myNumber < 0) {
+            myNumber = myNumber * -1;
+            formattedNumber = ("0" + myNumber).slice(-2);
+            result = "-" + formattedNumber;
+        } else {
+            formattedNumber = ("0" + myNumber).slice(-2);
+            result = "+" + formattedNumber;
+        }
+        return result;
     },
 
     //


### PR DESCRIPTION
The library has a issue with the getTimeZone function. It returns the Localized time on the JS Date with browser like Google Chrome. Ex:
Chrome returns: `Thu Aug 02 2018 18:10:30 GMT-0500 (Peru Standard Time)` instead `Thu Aug 02 2018 18:10:30 GMT-0500 (-05)` where `-05` should be the right return value.

This PR fixes issue #86 related to BST and GMT Daylight Time.

cc @jackspirou
cc @dsmontoya 