### PR TITLE
Update regex to fit with prestashop smartcache

### DIFF
--- a/src/vendor/ua-parser.js
+++ b/src/vendor/ua-parser.js
@@ -485,9 +485,9 @@
             /(dell)\s(strea[kpr\s\d]*[\dko])/i                                  // Dell Streak
             ], [VENDOR, MODEL, [TYPE, TABLET]], [
 
-            /(kf[A-z]+)\sbuild\/[\w\.]+.*silk\//i                               // Kindle Fire HD
+            /(kf[A-z]+)\sbuild\/[\w\.]+.*silk(\/){1}/i                               // Kindle Fire HD
             ], [MODEL, [VENDOR, 'Amazon'], [TYPE, TABLET]], [
-            /(sd|kf)[0349hijorstuw]+\sbuild\/[\w\.]+.*silk\//i                  // Fire Phone
+            /(sd|kf)[0349hijorstuw]+\sbuild\/[\w\.]+.*silk(\/){1}/i                  // Fire Phone
             ], [[MODEL, mapper.str, maps.device.amazon.model], [VENDOR, 'Amazon'], [TYPE, MOBILE]], [
 
             /\((ip[honed|\s\w*]+);.+(apple)/i                                   // iPod/iPhone
@@ -507,10 +507,10 @@
             /android.+(transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+|nexus 7)/i
             ], [MODEL, [VENDOR, 'Asus'], [TYPE, TABLET]], [
 
-            /(sony)\s(tablet\s[ps])\sbuild\//i,                                  // Sony
-            /(sony)?(?:sgp.+)\sbuild\//i
+            /(sony)\s(tablet\s[ps])\sbuild(\/){1}/i,                                  // Sony
+            /(sony)?(?:sgp.+)\sbuild(\/){1}/i
             ], [[VENDOR, 'Sony'], [MODEL, 'Xperia Tablet'], [TYPE, TABLET]], [
-            /(?:sony)?(?:(?:(?:c|d)\d{4})|(?:so[-l].+))\sbuild\//i
+            /(?:sony)?(?:(?:(?:c|d)\d{4})|(?:so[-l].+))\sbuild(\/){1}/i
             ], [[VENDOR, 'Sony'], [MODEL, 'Xperia Phone'], [TYPE, MOBILE]], [
 
             /\s(ouya)\s/i,                                                      // Ouya
@@ -544,12 +544,12 @@
             ], [[MODEL, /\./g, ' '], [VENDOR, 'Microsoft'], [TYPE, MOBILE]], [
 
                                                                                 // Motorola
-            /\s(milestone|droid(?:[2-4x]|\s(?:bionic|x2|pro|razr))?(:?\s4g)?)[\w\s]+build\//i,
+            /\s(milestone|droid(?:[2-4x]|\s(?:bionic|x2|pro|razr))?(:?\s4g)?)[\w\s]+build(\/){1}/i,
             /mot[\s-]?(\w+)*/i,
-            /(XT\d{3,4}) build\//i,
+            /(XT\d{3,4}) build(\/){1}/i,
             /(nexus\s[6])/i
             ], [MODEL, [VENDOR, 'Motorola'], [TYPE, MOBILE]], [
-            /android.+\s(mz60\d|xoom[\s2]{0,2})\sbuild\//i
+            /android.+\s(mz60\d|xoom[\s2]{0,2})\sbuild(\/){1}/i
             ], [MODEL, [VENDOR, 'Motorola'], [TYPE, TABLET]], [
 
             /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9|nexus 10))/i,


### PR DESCRIPTION
Prestashop smartcache concatenate all your javascript files into one to improve performances. He read `//` in regular expressions as a comment. Therefore, all the code after it, is not include in the final javascript file compiled by prestashop.
So, to be able to work with Prestashop smartcache, I suggest, this regex simplification.

Thank you for keeping me informed.