### PR TITLE
bump vulnerable ua-parser-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10882,9 +10882,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "globalthis": "^1.0.2",
     "inherits": "^2.0.4",
     "murmurhash-js": "^1.0.0",
-    "ua-parser-js": "^0.7.28"
+    "ua-parser-js": "^0.7.30"
   },
   "license": "Apache-2.0",
   "licenses": [


### PR DESCRIPTION
There's a malicious ua-parser-js NPM takeover, this PR bumps ua-parser-js version to the safe 0.7.30.

Security advisory: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
GH thread: faisalman/ua-parser-js#536
